### PR TITLE
Add integration of tinkoff-wrapper and statistics-service

### DIFF
--- a/statistics-service/src/main/kotlin/backend/statistics/StatisticsAggregator.kt
+++ b/statistics-service/src/main/kotlin/backend/statistics/StatisticsAggregator.kt
@@ -4,7 +4,7 @@ import backend.statistics.model.ActionInfo
 import backend.statistics.model.ReportType
 import backend.statistics.storage.MockStorage
 
-class StatisticsAgregator {
+class StatisticsAggregator {
 
     fun getActionsByBotId(botId: Int): MutableList<ActionInfo> {
         val botSales = getActionsByBotId(ReportType.SELL, botId)
@@ -19,8 +19,8 @@ class StatisticsAgregator {
 
     fun getActionsByBotId(report: ReportType, botId: Int): MutableList<ActionInfo> {
         return when(report) {
-            ReportType.BUY -> MockStorage.salesPerBot.getOrDefault(botId, mutableListOf())
-            ReportType.SELL -> MockStorage.purchasesPerBot.getOrDefault(botId, mutableListOf())
+            ReportType.BUY -> MockStorage.purchasesPerBot.getOrDefault(botId, mutableListOf())
+            ReportType.SELL -> MockStorage.salesPerBot.getOrDefault(botId, mutableListOf())
         }
     }
 }

--- a/tinkoff-wrapper/build.gradle.kts
+++ b/tinkoff-wrapper/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":statistics-service"))
+
     implementation("org.slf4j:slf4j-api:2.0.3")
     implementation("org.slf4j:slf4j-simple:2.0.3")
     implementation("ru.tinkoff.piapi:java-sdk-core:1.0.14")

--- a/tinkoff-wrapper/src/main/kotlin/backend/tinkoff/account/TinkoffVirtualAccount.kt
+++ b/tinkoff-wrapper/src/main/kotlin/backend/tinkoff/account/TinkoffVirtualAccount.kt
@@ -1,5 +1,8 @@
 package backend.tinkoff.account
 
+import backend.statistics.StatisticsReporter
+import backend.statistics.model.ActionInfo
+import backend.statistics.model.ReportType
 import backend.tinkoff.error.*
 import backend.tinkoff.error.waitForSuccess
 import backend.tinkoff.model.*
@@ -24,6 +27,7 @@ class TinkoffVirtualAccount(
         return actualAccount.postBuyOrder(figi, quantity, price).onSuccess {
             onPostBuyOrder(it)
             onSuccessOrderIfExecuted(OrderState.fromPostOrderResponse(it))
+            StatisticsReporter.report(ReportType.BUY, botUid, ActionInfo(figi, quantity, price.toString()))
         }
     }
 
@@ -34,6 +38,7 @@ class TinkoffVirtualAccount(
         return actualAccount.postSellOrder(figi, quantity, price).onSuccess {
             onPostSellOrder(it)
             onSuccessOrderIfExecuted(OrderState.fromPostOrderResponse(it))
+            StatisticsReporter.report(ReportType.SELL, botUid, ActionInfo(figi, quantity, price.toString()))
         }
     }
 


### PR DESCRIPTION
После 2 заявок на покупку (одна выполнена сразу, другая ожидает в очереди) и одной заявки на продажу (успешно выполнена), видим в статистике следующее:

![image](https://user-images.githubusercontent.com/54814796/197891825-b777d763-1f8c-4313-a2c6-84592e8d56f1.png)

![image](https://user-images.githubusercontent.com/54814796/197891871-21642501-958f-4157-b2c7-98fc0700f528.png)

Заявки выставлялись напрямую от TinkoffVirtualAccount, без участия ботов